### PR TITLE
Consumer config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 data
+bin
+kcr
 
 HELP.md
 .gradle

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/Kcr.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/Kcr.kt
@@ -26,7 +26,7 @@ import java.util.*
 class KcrVersion {
     //TODO derive from gradle build.
     companion object {
-        const val VERSION = "0.1"
+        const val VERSION = "0.2"
     }
 }
 


### PR DESCRIPTION
Added --producer-config to kcr-play to set/override Kakfa Producer properties. Fixed dxception/crash occurred during playback when cassette contained more partitions than the target topic - added try/catch and simple mapping of partitions.