### PR TITLE
Feature/390 add duration to record/playback

### DIFF
--- a/src/main/kotlin/com/nordstrom/kafka/kcr/cassette/CassetteInfo.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/cassette/CassetteInfo.kt
@@ -40,6 +40,7 @@ class CassetteInfo(val cassette: String) {
     private val latest: Instant
     private val partitions: MutableList<CassettePartitionInfo> = mutableListOf()
     val totalRecords: Int
+    val clength: Duration
 
     init {
         val filelist = File(cassette).list()
@@ -55,6 +56,7 @@ class CassetteInfo(val cassette: String) {
         val t1 = partitions.stream().map(CassettePartitionInfo::latest).max(Long::compareTo)
         earliest = Date(t0.get()).toInstant()
         latest = Date(t1.get()).toInstant()
+        clength = Duration.between(earliest, latest)
         totalRecords = partitions.sumBy { it.count }
     }
 

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/cassette/CassetteInfo.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/cassette/CassetteInfo.kt
@@ -37,10 +37,10 @@ class CassetteInfo(val cassette: String) {
     }
 
     val earliest: Instant
-    private val latest: Instant
-    private val partitions: MutableList<CassettePartitionInfo> = mutableListOf()
+    val latest: Instant
+    val partitions: MutableList<CassettePartitionInfo> = mutableListOf()
     val totalRecords: Int
-    val clength: Duration
+    val cassetteLength: Duration
 
     init {
         val filelist = File(cassette).list()
@@ -56,7 +56,7 @@ class CassetteInfo(val cassette: String) {
         val t1 = partitions.stream().map(CassettePartitionInfo::latest).max(Long::compareTo)
         earliest = Date(t0.get()).toInstant()
         latest = Date(t1.get()).toInstant()
-        clength = Duration.between(earliest, latest)
+        cassetteLength = Duration.between(earliest, latest)
         totalRecords = partitions.sumBy { it.count }
     }
 
@@ -67,7 +67,7 @@ class CassetteInfo(val cassette: String) {
 |  o___o  | tracks  : ${partitions.size}
 |__/___\__| songs   : $totalRecords
             recorded: $earliest - $latest
-            length  : ${Duration.between(earliest, latest)}
+            length  : $cassetteLength
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Play.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Play.kt
@@ -150,14 +150,13 @@ class Play : CliktCommand(name = "play", help = "Playback a cassette to a Kafka 
 
         val filelist = File(cassette).list()
         var cassetteLength = cinfo.cassetteLength.toMillis()
-        var numDuration: Long = 0
+        var timeLeftMillis: Long = 0
 
         if(hasDuration){
             var parts = duration!!.split("h", "m", "s")
-            numDuration = (parts[0].toDouble() * 3600000 + parts[1].toDouble() * 60000 + parts[2].toDouble() * 1000).toLong()
+            timeLeftMillis = (parts[0].toDouble() * 3600000 + parts[1].toDouble() * 60000 + parts[2].toDouble() * 1000).toLong()
         }
 
-        var timeLeftMillis = numDuration
         val startKcr = Date().toInstant()
         runBlocking{
             while ( shouldContinue(iRuns, timeLeftMillis) ) {

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Play.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Play.kt
@@ -83,7 +83,6 @@ class Play : CliktCommand(name = "play", help = "Playback a cassette to a Kafka 
     // entry
     //
     override fun run() {
-
         if(numberOfRuns.isNullOrEmpty().not()){
             intNumberOfRuns = numberOfRuns!!.toInt()
             if(duration.isNullOrEmpty().not()){
@@ -92,6 +91,15 @@ class Play : CliktCommand(name = "play", help = "Playback a cassette to a Kafka 
             }
         } else{
             intNumberOfRuns = 1
+        }
+
+        if(duration.isNullOrEmpty().not()){
+            val regex = Regex("""(\d.*)h(\d.*)m(\d.*)s""")
+            val matched = regex.matches(input = duration!!.toString())
+            if(!matched){
+                println("Duration must be in the format of **h**m**s, '**' must be integer or decimal. Please try again!")
+                System.exit(0)
+            }
         }
 
         //TODO show()
@@ -153,7 +161,7 @@ class Play : CliktCommand(name = "play", help = "Playback a cassette to a Kafka 
 
         if(duration.isNullOrEmpty().not()){
             var parts = duration!!.split("h", "m", "s")
-            num_duration = parts[0].toLong() * 3600000 + parts[1].toLong() * 60000 + (parts[2].toDouble() * 1000).toLong()
+            num_duration = (parts[0].toDouble() * 3600000 + parts[1].toDouble() * 60000 + parts[2].toDouble() * 1000).toLong()
         }
 
         var left_duration = num_duration

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Record.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/Record.kt
@@ -67,6 +67,14 @@ class Record : CliktCommand(name = "record", help = "Record a Kafka topic to a c
     // entry
     //
     override fun run() {
+        if(duration.isNullOrEmpty().not()){
+            val regex = Regex("""(\d.*)h(\d.*)m(\d.*)s""")
+            val matched = regex.matches(input = duration!!.toString())
+            if(!matched){
+                println("Duration must be in the format of **h**m**s, '**' must be integer or decimal. Please try again!")
+                System.exit(0)
+            }
+        }
         println("kcr.record.id              : ${opts["kcr.id"]}")
         println("kcr.record.topic           : $topic")
         val metricDurationTimer = Timer.start()
@@ -119,7 +127,7 @@ class Record : CliktCommand(name = "record", help = "Record a Kafka topic to a c
             if(duration.isNullOrEmpty().not()){
                 try{
                     var parts = duration!!.split("h", "m", "s")
-                    var num_duration: Long = parts[0].toLong() * 3600000 + parts[1].toLong() * 60000 + (parts[2].toDouble() * 1000).toLong()
+                    var num_duration: Long = (parts[0].toDouble() * 3600000 + parts[1].toDouble() * 60000 + parts[2].toDouble() * 1000).toLong()
                     delay(num_duration)
                     coroutineContext[Job]?.cancel()
                     throw Exception("coroutine cancellation")


### PR DESCRIPTION
Add --duration argv to record/playback to record or playback for a specified duration.

Must use a duration format as --duration=xxxhxxxmxxxs

For playback, cassette is repeated until duration expires if the cassette play-length is less than the duration.

Also, for playback, --duration and --number-of-runs is mutually exclusive.
