### PR TITLE
Use picocli for command-line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 data
 bin
-kcr
+/kcr
 
 HELP.md
 .gradle

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kafka Cassette Recorder
 A utility to record and playback messages from any Kafka topic.  This tool can be useful to capture
 production data streams for playback in a disaster recovery scenario or for load testing.
 
-Message key and value are stored as ASCII-encoded hexidecimal along with message header parameters
+Message key and value are stored as ASCII-encoded hexadecimal along with message header parameters
 (stored as string key/value).
 
 Messages are stored in a 'cassette' (data directory) by partition.  Playback of a cassette is at the
@@ -16,73 +16,89 @@ Storage format is in json.
 ## Usage
 
 ```
-$ kcr --help
+$ ./kcr.sh help
 
-Usage: kcr [OPTIONS] COMMAND [ARGS]...
-
-  Apache Kafka topic record/playback tool
-
-Options:
-  --bootstrap-servers TEXT  Kafka bootstrap server list
-  --security-protocol TEXT  Security protocol
-  --sasl-mechanism TEXT     SASL mechanism
-  --sasl-username TEXT      SASL username
-  --sasl-password TEXT      SASL password
-  -h, --help                Show this message and exit
-
+Usage: kcr [-hV] [--bootstrap-servers=<bootstrapServers>] [--sasl-mechanism=<saslMechanism>]
+           [--sasl-password=<saslPassword>] [--sasl-username=<saslUsername>] [--security-protocol=<securityProtocol>]
+           [COMMAND]
+      --bootstrap-servers=<bootstrapServers>
+                  Kafka bootstrap server list; default: localhost:9092
+  -h, --help      Show this help message and exit.
+      --sasl-mechanism=<saslMechanism>
+                  SASL mechanism; default: SCRAM-SHA-512
+      --sasl-password=<saslPassword>
+                  SASL password
+      --sasl-username=<saslUsername>
+                  SASL username
+      --security-protocol=<securityProtocol>
+                  Security protocol; default: PLAINTEXT
+  -V, --version   Print version information and exit.
 Commands:
   play    Playback a cassette to a Kafka topic.
   record  Record a Kafka topic to a cassette.
-
-v0.1/0.1
+  help    Displays help information about the specified command
 ```
 
 ### Record
 
 ```
-$ kcr record --help
+$ ./kcr.sh record help
 
-Usage: kcr record [OPTIONS]
-
-  Record a Kafka topic to a cassette.
-
-Options:
-  --data-directory TEXT    Kafka Cassette Recorder data directory for
-                           recording (default=kcr)
-  --group-id TEXT          Kafka consumer group id (default=kcr-<topic>-gid)
-  --topic TEXT             Kafka topic to record (REQUIRED)
-  --duration TEXT          Kafka duration for recording, format must be like
-                           **h**m**s
-  --header-timestamp TEXT  Use timestamp from header parameter ignoring record
-                           timestamp
-  --consumer-config TEXT   Optional Kafka Consumer configuration file.
-                           OVERWRITES any command-line values.
-  -h, --help               Show this message and exit
+Usage: kcr record [-hV] [--consumer-config=<properties>]
+                  [--data-directory=<dataDirectory>]
+                  [--duration=<durationValue>] [--group-id=<groupId>]
+                  [--timestamp-header-name=<timestampHeaderName>]
+                  --topic=<topic>
+Record a Kafka topic to a cassette.
+      --consumer-config=<properties>
+                             Optional Kafka Consumer configuration file.
+                               OVERWRITES any command-line values.
+      --data-directory=<dataDirectory>
+                             Kafka Cassette Recorder data directory for
+                               recording (default=kcr)
+      --duration=<durationValue>
+                             Duration for playback; format must be like
+                               **h**m**s
+      --group-id=<groupId>   Kafka consumer group id (default=kcr-<topic>-gid)
+  -h, --help                 Show this help message and exit.
+      --timestamp-header-name=<timestampHeaderName>
+                             Kafka message header parameter to extract and use
+                               as the record timestamp in epoch format,
+                               ignoring record timestamp
+      --topic=<topic>        Kafka topic to record
+  -V, --version              Print version information and exit.
 ```
 
 ### Play
 
 ```
-$kcr play --help
+$./kcr play help
 
-Usage: kcr play [OPTIONS]
-
-  Playback a cassette to a Kafka topic.
-
-Options:
-  --cassette TEXT         Kafka Cassette Recorder directory for playback
-                          (REQUIRED)
-  --playback-rate FLOAT   Playback rate multiplier (1.0 = play at capture
-                          rate, 2.0 = playback at twice capture rate)
-  --topic TEXT            Kafka topic to write (REQUIRED)
-  --producer-config TEXT  Optional Kafka Producer configuration file.
-                          OVERWRITES any command-line values.
-  --info                  List information about a Cassette, then exit
-  --pause                 Pause at end of playback (ctrl-c to exit)
-  --number-of-runs TEXT   Number of times to run the playback
-  --duration TEXT         Kafka duration for playback, format must be like
-                          **h**m**s
-  -h, --help              Show this message and exit
+Usage: kcr play [-hV] [--info] [--pause] --cassette=<cassette>
+                [--duration=<durationValue>]
+                [--number-of-plays=<numberOfPlaysValue>]
+                [--playback-rate=<playbackRate>]
+                [--producer-config=<properties>] --topic=<topic>
+Playback a cassette to a Kafka topic.
+      --cassette=<cassette>
+                        Kafka Cassette Recorder cassette directory for playback
+      --duration=<durationValue>
+                        Duration for playback; format must be like **h**m**s
+  -h, --help            Show this help message and exit.
+      --info            List information about a cassette, then exit
+                          (default=false)
+      --number-of-plays=<numberOfPlaysValue>
+                        Number of times to play the cassette
+      --pause           Pause at end of playback; ctrl-c to exit (default=false)
+      --playback-rate=<playbackRate>
+                        Playback rate multiplier (0 = playback as fast as
+                          possible, 1.0 = play at capture rate, 2.0 = playback
+                          at twice capture rate, default=1.0)
+      --producer-config=<properties>
+                        Optional Kafka Producer configuration file. OVERWRITES
+                          any command-line values.
+      --topic=<topic>   Kafka topic to write.
+  -V, --version         Print version information and exit.
 ```
 
 ## Metrics
@@ -118,13 +134,13 @@ gradle clean build
 Create a recording from a simple, local cluster:
 
 ```
-java -jar ./build/libs/kcr-all.jar record --topic my-topic --data-directory data
+./kcr.sh record --topic my-topic --data-directory data
 ```
 
 Create a recording from secure cluster, like Confluent Cloud:
 
 ```
-java -jar ./build/libs/kcr-all.jar --bootstrap-servers $MY_BOOTSTRAP_SERVERS --security-protocol SASL_PLAIN --sasl-mechanism PLAIN --sasl-username $MY_SASL_USERNAME --sasl-password $MY_SASL_PASSWORD record --topic my-topic --data-directory data
+./kcr.sh --bootstrap-servers $MY_BOOTSTRAP_SERVERS --security-protocol SASL_PLAIN --sasl-mechanism PLAIN --sasl-username $MY_SASL_USERNAME --sasl-password $MY_SASL_PASSWORD record --topic my-topic --data-directory data
 ```
 
 ### Playback (wip)
@@ -132,21 +148,7 @@ java -jar ./build/libs/kcr-all.jar --bootstrap-servers $MY_BOOTSTRAP_SERVERS --s
 Playback is at the capture rate of the cassette (i.e., if you recorded a stream with 5 message/sec, playback will also be at 5 message/sec)
 
 ```
-java -jar ./build/libs/kcr-all.jar play --cassette data/my-topic-yyyymmdd_hhmm --topic my-topic-too
-```
-
-### Helper scripts
-
-```
-./scripts/kcr-record <TOPIC>
-
-#e.g., ./scripts/kcr-record sea-of-time
-```
-
-```
-./scripts/kcr-playback <TARGET_TOPIC> <CASSETTE_DIR>
-
-#e.g., ./scripts/kcr-playback sea-of-science ./data/kcr-sea-of-time-20190517-1708
+./kcr.sh play --cassette data/my-topic-yyyymmdd_hhmm --topic my-topic-too
 ```
 
 # Example
@@ -158,6 +160,5 @@ The `./example` directory has a `docker-compose.yml` that will start a local kaf
 
 # Roadmap
 
-* Switch to `picocli` for command-line arguments
-* Use `avro` for cassette format
 * Record / playback from AWS S3
+* Use `avro` for cassette format

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # kcr
 Kafka Cassette Recorder
 
+NB: V2.0 had a bug that did not allow playback. DO NOT USE
+
 A utility to record and playback messages from any Kafka topic.  This tool can be useful to capture
 production data streams for playback in a disaster recovery scenario or for load testing.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     // NB: plugin versions pinned in settings.gradle
     id("org.jetbrains.kotlin.jvm")
@@ -6,32 +8,21 @@ plugins {
     id("com.github.johnrengelman.shadow")
     id("com.adarshr.test-logger")
     id("com.diffplug.spotless")
-}
-
-ext {
-    commonsCodecVersion = "1.15"
-    kafkaVersion = "2.5.1"
-
-    kotlinxCoroutinesVersion = "1.4.2"
-    kotlinxSerializationVersion = "1.0.0"
-    kotestVersion = "4.3.1"
-
-    jupiterVersion = "5.7.0"
-
-    picocliVersion = "4.6.1"
-
-    slf4jVersion = "1.7.30"
+    id("net.nemerosa.versioning")
 }
 
 group = "com.nordstrom.kafka.kcr"
 
-mainClassName = "com.nordstrom.kafka.kcr.KcrKt"
+application {
+    mainClassName = "com.nordstrom.kafka.kcr.Kcr"
+}
 
 sourceSets {
     deploy
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 
@@ -46,14 +37,18 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
     // Application dependencies
-//    implementation("info.picocli:picocli:$picocliVersion")
+    implementation("info.picocli:picocli:$picocliVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
     implementation("org.slf4j:slf4j-simple:$slf4jVersion")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     implementation("com.github.ajalt:clikt:1.7.0")
+//    implementation("com.github.ajalt.clikt:clikt:$cliKtVersion")
     implementation("io.micrometer:micrometer-registry-statsd:latest.release")
     implementation("io.micrometer:micrometer-registry-jmx:latest.release")
     implementation("commons-codec:commons-codec:$commonsCodecVersion")
+    implementation platform("software.amazon.awssdk:bom:$awsSdkVersion")
+    implementation("software.amazon.awssdk:s3")
+    implementation("software.amazon.awssdk:netty-nio-client")
 
     // Test
     testImplementation("org.jetbrains.kotlin:kotlin-test")
@@ -64,7 +59,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "11"
         //NB: Need this for kotlinx-serialization
@@ -81,6 +76,8 @@ test {
     testlogger {
         theme("mocha-parallel")
         showExceptions(true)
+        showCauses(true)
+        showStackTraces(true)
         showStandardStreams(true)
     }
 }
@@ -89,5 +86,22 @@ spotless {
     java {
         googleJavaFormat("1.9")
         removeUnusedImports()
+    }
+}
+
+version = "${versioning.info.lastTag}.${System.env.CI_PIPELINE_ID ?: 'dev'}"
+versioning {
+    noWarningOnDirty = true
+}
+processResources.dependsOn.add("generateVersionFile")
+task generateVersionFile {
+    doLast {
+        new File(project.buildDir, 'resources/main').mkdirs()
+        new File(project.buildDir, 'resources/main/version.properties')
+                .withWriter('utf-8') { writer ->
+                    writer.writeLine "version = ${project.version}"
+                    writer.writeLine "git.branch = ${project.versioning.info.branch}"
+                    writer.writeLine "git.commit = ${project.versioning.info.commit}"
+                }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,20 @@
-kotlin.code.style=official
-
+kotlin.code.style = official
 kotlinVersion = 1.4.21
+
+awsSdkVersion = 2.15.0
+
+commonsCodecVersion = 1.15
+
+kafkaVersion = 2.5.1
+
+kotlinxCoroutinesVersion = 1.4.2
+kotlinxSerializationVersion = 1.0.0
+kotestVersion = 4.3.1
+
+jupiterVersion = 5.7.0
+
+log4jVersion = 2.14.0
+
+picocliVersion = 4.6.1
+
+slf4jVersion = 1.7.30

--- a/kcr.sh
+++ b/kcr.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [[ -z "${KCR_TRUSTSTORE}" ]] ; then
+  KCR_TRUSTSTORE="${HOME}/var/private/truststore.jks"
+fi
+if [[ -z "${KCR_JAAS_CONF}" ]] ; then
+  KCR_JAAS_CONF="${HOME}/var/private/jaas.conf"
+fi
+
+#needed to enable monitoring tools (jconsole, visualvm, etc)
+OPTS="-Djava.rmi.server.hostname=127.0.0.1"
+
+script_dir() {
+  SOURCE="${BASH_SOURCE[0]}"
+  # While $SOURCE is a symlink, resolve it
+  while [ -h "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$( readlink "$SOURCE" )"
+    # If $SOURCE was a relative symlink (no "/" as prefix) then
+    # we need to resolve it relative to the symlink base directory
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+  done
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  echo "$DIR"
+}
+
+build_dir() {
+  BASEDIR=$( script_dir )
+  if [[ -d $BASEDIR/.git ]]; then
+    echo "$BASEDIR/build/libs/"
+  else
+    echo "$BASEDIR/"
+  fi
+}
+
+cli_filepath() {
+  for jar in $( build_dir )kcr-*-all.jar; do
+    [[ -f "$jar" ]] && echo $jar
+    break
+  done
+}
+
+cli_exists() {
+  [[ -z "$( cli_filepath )" ]] && return 1
+  return 0
+}
+
+if cli_exists; then
+  java $OPTS \
+   -Djava.security.auth.login.config=$KCR_JAAS_CONF \
+   -Djavax.net.ssl.trustStore=$KCR_TRUSTSTORE \
+   -Djavax.net.ssl.trustStoreType=JKS \
+   -jar $( cli_filepath ) "$@"
+else
+  { echo -e "\e[01;31mOops!\e[0m kcr couldn't be found at $( build_dir )" >&2; exit 1; }
+fi

--- a/scripts/kcr-playback
+++ b/scripts/kcr-playback
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-TOPIC=$1
-CASSETTE=$2
-
-#needed to enable monitoring tools (jconsole, visualvm, etc)
-OPTS="-Djava.rmi.server.hostname=127.0.0.1"
-java $OPTS -jar build/libs/kcr-all.jar play --cassette $CASSETTE --topic $TOPIC

--- a/scripts/kcr-playback-fast
+++ b/scripts/kcr-playback-fast
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-TOPIC=$1
-CASSETTE=$2
-
-#needed to enable monitoring tools (jconsole, visualvm, etc)
-OPTS="-Djava.rmi.server.hostname=127.0.0.1"
-java $OPTS -jar build/libs/kcr-all.jar play --cassette $CASSETTE --topic $TOPIC --playback-rate -1.0

--- a/scripts/kcr-record
+++ b/scripts/kcr-record
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-TOPIC=$1
-
-#needed to enable monitoring tools (jconsole, visualvm, etc)
-OPTS="-Djava.rmi.server.hostname=127.0.0.1"
-java $OPTS -jar build/libs/kcr-all.jar record --topic $TOPIC

--- a/scripts/kcr-run
+++ b/scripts/kcr-run
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-#needed to enable monitoring tools (jconsole, visualvm, etc)
-OPTS="-Djava.rmi.server.hostname=127.0.0.1"
-java $OPTS -jar build/libs/kcr-all.jar $@

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version "5.2.0"
         id("com.adarshr.test-logger") version "2.1.1"
         id("com.diffplug.spotless") version "5.9.0"
+        id("net.nemerosa.versioning") version "2.11.0"
     }
 }
 

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/CliVersionProvider.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/CliVersionProvider.kt
@@ -1,0 +1,16 @@
+package com.nordstrom.kafka.kcr
+
+import picocli.CommandLine
+import java.util.*
+
+class CliVersionProvider : CommandLine.IVersionProvider {
+    val properties = Properties()
+
+    init {
+        CliVersionProvider::class.java.classLoader.getResourceAsStream("version.properties").use {
+            properties.load(it)
+        }
+    }
+
+    override fun getVersion() = arrayOf("kcr ${properties.getProperty("version")}");
+}

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/Kcr.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/Kcr.kt
@@ -1,70 +1,36 @@
 package com.nordstrom.kafka.kcr
 
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.findObject
-import com.github.ajalt.clikt.core.subcommands
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.option
-import com.nordstrom.kafka.kcr.cassette.CassetteVersion
-import com.nordstrom.kafka.kcr.commands.Play
-import com.nordstrom.kafka.kcr.commands.Record
+import com.nordstrom.kafka.kcr.commands.PlayCommand
+import com.nordstrom.kafka.kcr.commands.RecordCommand
 import com.nordstrom.kafka.kcr.facilities.AlphaNumKeyGenerator
-import org.slf4j.LoggerFactory
-import java.util.*
+import com.nordstrom.kafka.kcr.kafka.KafkaOptions
+import picocli.CommandLine
+import kotlin.system.exitProcess
 
-
-class KcrVersion {
-    //TODO derive from gradle build.
-    companion object {
-        const val VERSION = "2.0"
-    }
-}
-
-class Kcr : CliktCommand(
+@CommandLine.Command(
     name = "kcr",
-    help = "Apache Kafka topic record/playback tool",
-    epilog = "v${KcrVersion.VERSION}/${CassetteVersion.VERSION}"
-) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        PlayCommand::class,
+        RecordCommand::class,
+        CommandLine.HelpCommand::class,
+    ],
+    usageHelpWidth = 120,
+    versionProvider = CliVersionProvider::class
+)
+class Kcr : Runnable {
+    @CommandLine.Mixin
+    lateinit var kafkaOptions: KafkaOptions
 
-    private val bootstrapServers by option(help = "Kafka bootstrap server list").default("localhost:9092")
-    private val securityProtocol by option(help = "Security protocol").default("PLAINTEXT")
-    private val saslMechanism by option(help = "SASL mechanism")
-    private val saslUsername by option(help = "SASL username").default("")
-    private val saslPassword by option(help = "SASL password").default("")
+    override fun run() = CommandLine(Kcr()).usage(System.out)
 
-    private val opts by findObject { Properties() }
+    companion object {
+        val id: String = AlphaNumKeyGenerator().key(8)
 
-    override fun run() {
-        opts["kcr.id"] = id
-        opts["bootstrap.servers"] = bootstrapServers
-        opts["security.protocol"] = securityProtocol
-
-        if (securityProtocol.startsWith("SASL")) {
-            saslMechanism?.let {
-                opts["sasl.mechanism"] = saslMechanism
-            }
-
-            opts["sasl.jaas.config"] = when (saslMechanism) {
-                "PLAIN" -> "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${saslUsername}\" password=\"${saslPassword}\";"
-                "SCRAM-SHA-256", "SCRAM-SHA-512" -> "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${saslUsername}\" password=\"${saslPassword}\";"
-                else -> "" // Not supported
-            }
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val exitCode = CommandLine(Kcr()).execute(*args)
+            exitProcess(exitCode)
         }
     }
-
-
-    companion object {
-        // Make run-id available to everyone.
-        val id = AlphaNumKeyGenerator().key(8)
-    }
-
 }
-
-
-//
-// KcrKt - main
-//
-fun main(args: Array<String>) = Kcr()
-    .subcommands(Play(), Record())
-    .main(args)

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/NullRecorder.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/NullRecorder.kt
@@ -4,7 +4,7 @@ import java.util.*
 
 class NullRecorder(
     val config: Properties,
-    val cassetteName:String?
+    val cassetteName: String?
 ) {
     init {
         println("kcr-null-recorder.init.OK")

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/options/Options.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/options/Options.kt
@@ -1,0 +1,113 @@
+package com.nordstrom.kafka.kcr.commands.options
+
+import picocli.CommandLine
+import java.io.File
+import java.io.FileInputStream
+import java.util.*
+
+class DurationOption {
+    @CommandLine.Spec
+    lateinit var spec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Option(
+        names = ["--duration"],
+        description = ["Duration for playback; format must be like **h**m**s"],
+    )
+    fun setDurationValue(value: String) {
+        var valid = true
+        valid = valid && value.isNotBlank()
+        valid = valid && Regex("""(\d.*)h(\d.*)m(\d.*)s""").matches(input = value)
+        if (!valid) {
+            throw CommandLine.ParameterException(
+                spec.commandLine(),
+                "--duration must be in the format of **h**m**s, '**' must be integer or decimal. Please try again!"
+            )
+        }
+
+        val parts = value.split("h", "m", "s")
+        millis =
+            (parts[0].toDouble() * 3600000 + parts[1].toDouble() * 60000 + parts[2].toDouble() * 1000).toLong()
+        isPresent = true
+    }
+
+    var millis = 0L
+    var isPresent = false
+}
+
+class NumberOfPlaysOption {
+    @CommandLine.Spec
+    lateinit var spec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Option(
+        names = ["--number-of-plays"],
+        description = ["Number of times to play the cassette"],
+    )
+    fun setNumberOfPlaysValue(value: Int) {
+        if (value <= 0) {
+            throw CommandLine.ParameterException(
+                spec.commandLine(),
+                "--number-of-plays must be greater than 0"
+            )
+        }
+        count = value
+        isPresent = true
+    }
+
+    var count: Int = 0
+    var isPresent = false
+
+}
+
+class ConsumerConfigOption {
+    @CommandLine.Spec
+    lateinit var spec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Option(
+        names = ["--consumer-config"],
+        description = ["Optional Kafka Consumer configuration file. OVERWRITES any command-line values."],
+    )
+    fun setProperties(value: File) {
+        if (value.isFile.not()) {
+            throw CommandLine.ParameterException(
+                spec.commandLine(),
+                "File not found: $value"
+            )
+        }
+
+        properties.load(FileInputStream(value))
+
+        file = value
+        isPresent = true
+    }
+
+    lateinit var file: File
+    var properties = Properties()
+    var isPresent = false
+}
+
+class ProducerConfigOption {
+    @CommandLine.Spec
+    lateinit var spec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Option(
+        names = ["--producer-config"],
+        description = ["Optional Kafka Producer configuration file. OVERWRITES any command-line values."],
+    )
+    fun setProperties(value: File) {
+        if (value.isFile.not()) {
+            throw CommandLine.ParameterException(
+                spec.commandLine(),
+                "File not found: $value"
+            )
+        }
+
+        properties.load(FileInputStream(value))
+
+        file = value
+        isPresent = true
+    }
+
+    lateinit var file: File
+    var properties = Properties()
+    var isPresent = false
+}

--- a/src/main/kotlin/com/nordstrom/kafka/kcr/kafka/KafkaOptions.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/kafka/KafkaOptions.kt
@@ -1,0 +1,77 @@
+package com.nordstrom.kafka.kcr.kafka
+
+import picocli.CommandLine
+import java.util.*
+
+class KafkaOptions {
+    @CommandLine.Option(
+        names = ["--bootstrap-servers"],
+        defaultValue = "\${env:KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}",
+        description = ["Kafka bootstrap server list; default: \${DEFAULT-VALUE}"]
+    )
+    var bootstrapServers: String = ""
+
+    @CommandLine.Option(
+        names = ["--security-protocol"],
+        defaultValue = "PLAINTEXT", description = ["Security protocol; default: \${DEFAULT-VALUE}"]
+    )
+    var securityProtocol: String = ""
+
+    @CommandLine.Option(
+        names = ["--sasl-mechanism"],
+        defaultValue = "SCRAM-SHA-512", description = ["SASL mechanism; default: \${DEFAULT-VALUE}"]
+    )
+    var saslMechanism: String? = null
+
+    @CommandLine.Option(names = ["--sasl-username"], description = ["SASL username"])
+    var saslUsername: String? = System.getenv("KAFKA_SASL_USERNAME")
+
+    @CommandLine.Option(names = ["--sasl-password"], description = ["SASL password"])
+    var saslPassword: String? = System.getenv("KAFKA_SASL_PASSWORD")
+
+    fun toMap(): MutableMap<String, String> {
+        val propsMap = mutableMapOf(
+            "bootstrap.servers" to bootstrapServers,
+            "security.protocol" to securityProtocol,
+        )
+
+        saslMechanism?.let {
+            propsMap["sasl.mechanism"] = saslMechanism!!
+        }
+        saslUsername?.let {
+            propsMap["sasl.jaas.config"] =
+                "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${saslUsername}\" password=\"${saslPassword}\";"
+        }
+
+        return propsMap
+    }
+
+    // Default kafka producer properties
+    fun producerProperties(): Properties {
+        val kafkaMap = toMap()
+        kafkaMap["client.id"] = "kcr-client-0"
+        kafkaMap["key.serializer"] = "org.apache.kafka.common.serialization.ByteArraySerializer"
+        kafkaMap["value.serializer"] = "org.apache.kafka.common.serialization.ByteArraySerializer"
+
+        return kafkaMap.toProperties()
+    }
+
+    // Default kafka consumer properties
+    fun consumerProperties(): Properties {
+        val kafkaMap = toMap()
+        kafkaMap["key.deserializer"] = "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+        kafkaMap["value.deserializer"] =
+            "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+        kafkaMap["enable.auto.commit"] = "true"
+        kafkaMap["auto.offset.reset"] = "latest"
+
+        return kafkaMap.toProperties()
+    }
+
+    // Default kafka admin properties
+    fun adminProperties(): Properties {
+        val kafkaMap = toMap()
+
+        return kafkaMap.toProperties()
+    }
+}

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -15,6 +15,7 @@ org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr=info
 #org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr.commands=trace
 #org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr.commands.Play=trace
 #org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr.commands.Record=trace
+#org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr.commands.options=trace
 
 #org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr.io=info
 
@@ -24,4 +25,4 @@ org.slf4j.simpleLogger.log.com.nordstrom.kafka.kcr=info
 #org.slf4j.simpleLogger.log.io.micrometer=error
 
 # disable info messages from apache kafka
-org.slf4j.simpleLogger.log.org.apache.kafka=error
+org.slf4j.simpleLogger.log.org.apache.kafka=info


### PR DESCRIPTION
Fixes a bug in playback which did not handle the new hexadecimal format for the value.

Replace CliKt with PicoCli for handling command-line arguments.