### PR TITLE
Validate playback rate and limiting

### DIFF
--- a/src/main/kotlin/com/nordstrom/kafka/kcr/commands/PlaybackLimiter.kt
+++ b/src/main/kotlin/com/nordstrom/kafka/kcr/commands/PlaybackLimiter.kt
@@ -1,0 +1,40 @@
+package com.nordstrom.kafka.kcr.commands
+
+import com.nordstrom.kafka.kcr.cassette.CassetteRecord
+import java.time.Duration
+import java.time.Instant
+import java.time.Clock
+
+class PlaybackLimiter(
+    val playbackRate: Float,
+    val timeshiftNanos: Long,
+    val clock: Clock = Clock.systemUTC()
+) {
+    var previousTimestamp: Instant? = null
+
+    fun proposeDelay(record: CassetteRecord): Duration? {
+        return if (playbackRate == 0.0f) {
+            return null
+        } else {
+            val recordTimestamp = Instant.ofEpochMilli(record.timestamp)
+            val shiftedTimestamp = recordTimestamp.plusNanos(timeshiftNanos)
+
+            if (previousTimestamp == null) {
+                previousTimestamp = shiftedTimestamp
+                null
+            } else if (playbackRate < 1.0f) {
+                val delta = Duration.between(previousTimestamp ?: Instant.now(clock), shiftedTimestamp)
+                Duration.ofMillis((delta.toMillis() / playbackRate).toLong()).also {
+                    previousTimestamp = shiftedTimestamp
+                }
+            } else if (playbackRate > 1.0f) {
+                val delta = Duration.between(previousTimestamp ?: Instant.now(clock), shiftedTimestamp)
+                Duration.ofMillis((delta.toMillis() / playbackRate).toLong()).also {
+                    previousTimestamp = shiftedTimestamp.plus(it)
+                }
+            } else {
+                Duration.between(previousTimestamp, shiftedTimestamp)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/nordstrom/kafka/kcr/commands/PlaybackLimiterTests.kt
+++ b/src/test/kotlin/com/nordstrom/kafka/kcr/commands/PlaybackLimiterTests.kt
@@ -1,0 +1,61 @@
+package com.nordstrom.kafka.kcr.commands
+
+import com.nordstrom.kafka.kcr.commands.PlaybackLimiter
+import com.nordstrom.kafka.kcr.cassette.CassetteRecord
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.*
+
+class PlaybackLimiterTests {
+    @Test
+    fun `Should propose no delay for default playback rate`() {
+        val playbackLimiter = PlaybackLimiter(0f, 0, clock(0L))
+
+        val record1 = record(1000)
+        val record2 = record(2000)
+
+        assertNull(playbackLimiter.proposeDelay(record1))
+        assertNull(playbackLimiter.proposeDelay(record2))
+    }
+
+    @Test
+    fun `Should propose same delay for same playback rate`() {
+        val playbackLimiter = PlaybackLimiter(1.0f, 0, clock(0L))
+
+        val record1 = record(1000)
+        val record2 = record(2000)
+
+        assertNull(playbackLimiter.proposeDelay(record1))
+        assertEquals(Duration.ofMillis(1000), playbackLimiter.proposeDelay(record2))
+    }
+
+    @Test
+    fun `Should propose delay for slower playback rate`() {
+        val playbackLimiter = PlaybackLimiter(0.5f, 0, clock(0L))
+
+        val record1 = record(1000)
+        val record2 = record(2000)
+
+        assertNull(playbackLimiter.proposeDelay(record1))
+        assertEquals(Duration.ofMillis(2000), playbackLimiter.proposeDelay(record2))
+    }
+
+    @Test
+    fun `Should propose delay for faster playback rate`() {
+        val playbackLimiter = PlaybackLimiter(2.0f, 0, clock(0L))
+
+        val record1 = record(1000)
+        val record2 = record(2000)
+
+        assertNull(playbackLimiter.proposeDelay(record1))
+        assertEquals(Duration.ofMillis(500), playbackLimiter.proposeDelay(record2))
+    }
+
+    fun record(timestamp: Long): CassetteRecord =
+        CassetteRecord(mutableMapOf<String, String>(), timestamp, 0, 0, null, "")
+    fun clock(epochMillis: Long): Clock =
+        Clock.fixed(Instant.ofEpochMilli(epochMillis), ZoneId.of("UTC"))
+}


### PR DESCRIPTION
Discussed in #14, playback rates less than 1.0 are running as quickly as possible.

This change introduces a limiter to propose the best delay based on the record time shift and the delta between current and next record timestamps.